### PR TITLE
Align status/title left and user ID right in row layout

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/wdona/burnt_out/presentation/ui/components/tarea/CardTarea.kt
+++ b/composeApp/src/commonMain/kotlin/dev/wdona/burnt_out/presentation/ui/components/tarea/CardTarea.kt
@@ -52,6 +52,7 @@ fun CardTarea(tarea: Tarea, onClick: () -> Unit, onCompletar: () -> Unit) {
         Text(
             text = "${tarea.idUsuarioAsignado}" ,
             textAlign = TextAlign.End,
+            modifier = Modifier.padding(end = 8.dp)
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/wdona/burnt_out/presentation/ui/pantallas/tablero/DetalleTableroScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/wdona/burnt_out/presentation/ui/pantallas/tablero/DetalleTableroScreen.kt
@@ -1,10 +1,6 @@
 package dev.wdona.burnt_out.presentation.ui.pantallas.tablero
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -90,7 +86,17 @@ fun DetalleTableroContent(
                         .padding(16.dp)
                 )
             } else {
-                Text( "Estado, Titulo, idUsuarioAsignado" )
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Row {
+                        Text("Estado")
+                        Text("Título", Modifier.padding(start = 8.dp))
+                    }
+
+                    Text(text = "idUsuarioAsignado")
+                }
                 LazyColumn(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(12.dp),


### PR DESCRIPTION
Old:
<img width="830" height="145" alt="image" src="https://github.com/user-attachments/assets/800a2882-94af-41e0-842c-21c99c2388ac" />

New:
<img width="808" height="144" alt="image" src="https://github.com/user-attachments/assets/0227e392-6d03-4cf8-81eb-cebaecc43146" />